### PR TITLE
Benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bench.txt

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/storozhukBM/pcache
 
 go 1.15
+
+require golang.org/x/perf v0.0.0-20200318175901-9c9101da8316 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/storozhukBM/pcache
 
 go 1.15
-
-require golang.org/x/perf v0.0.0-20200318175901-9c9101da8316 // indirect

--- a/pcache_benchmark_test.go
+++ b/pcache_benchmark_test.go
@@ -1,0 +1,191 @@
+package pcache_test
+
+import (
+	"fmt"
+	"github.com/storozhukBM/pcache"
+	"hash/maphash"
+	"math/rand"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type cache interface {
+	Load(key string) (interface{}, bool)
+	Store(key string, value interface{})
+}
+
+var workerSets = []int{1, 2, 4, 8, 12, 16, 22, 28, 32}
+
+func BenchmarkPCacheLoadStore(b *testing.B) {
+	for _, r := range workerSets {
+		cache := pcache.NewPCache(80)
+		b.Run(fmt.Sprintf("w-%v", r), func(b *testing.B) {
+			benchLoadStore(b, r, cache)
+		})
+	}
+}
+
+func BenchmarkMutexCacheLoadStore(b *testing.B) {
+	for _, r := range workerSets {
+		cache := newMutexCache(80)
+		b.Run(fmt.Sprintf("w-%v", r), func(b *testing.B) {
+			benchLoadStore(b, r, cache)
+		})
+	}
+}
+
+func BenchmarkStripedCacheLoadStore(b *testing.B) {
+	for _, r := range workerSets {
+		cache := newStripedMapCache(80)
+		b.Run(fmt.Sprintf("w-%v", r), func(b *testing.B) {
+			benchLoadStore(b, r, cache)
+		})
+	}
+}
+
+func benchLoadStore(b *testing.B, workers int, cache cache) {
+	keys := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		keys = append(keys, strconv.Itoa(i))
+	}
+
+	count := uint64(0)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			idx := 0
+			hits := uint64(0)
+			for i := 0; i < b.N; i++ {
+				idx++
+				if idx == len(keys) {
+					idx = 0
+				}
+				cache.Store(keys[len(keys)-1-idx], keys[idx])
+				_, ok := cache.Load(keys[idx])
+				if ok {
+					hits++
+				}
+			}
+			atomic.AddUint64(&count, hits)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if rand.Float32() < 0.00001 {
+		b.Logf("hits: %v", atomic.LoadUint64(&count))
+	}
+}
+
+type stripe struct {
+	m                     sync.RWMutex
+	deletionProbeIdx      int
+	deletionProbeBoundary int
+	store                 map[string]interface{}
+}
+
+type stripedMapCache struct {
+	sizePerGoroutine int
+	stripes          []*stripe
+}
+
+func newStripedMapCache(sizePerGoroutine uint) *stripedMapCache {
+	cache := &stripedMapCache{
+		sizePerGoroutine: int(sizePerGoroutine),
+		stripes:          make([]*stripe, 0, 64),
+	}
+	for i := 0; i < 64; i++ {
+		cache.stripes = append(cache.stripes, &stripe{
+			m:                     sync.RWMutex{},
+			deletionProbeIdx:      0,
+			deletionProbeBoundary: 8,
+			store:                 make(map[string]interface{}),
+		})
+	}
+	return cache
+}
+
+func (m *stripedMapCache) Load(key string) (interface{}, bool) {
+	var h maphash.Hash
+	_, _ = h.WriteString(key)
+	idx := uint64(64-1) & h.Sum64()
+	stripe := m.stripes[idx]
+	stripe.m.RLock()
+	defer stripe.m.RUnlock()
+	val, ok := stripe.store[key]
+	return val, ok
+}
+
+func (m *stripedMapCache) Store(key string, value interface{}) {
+	var h maphash.Hash
+	_, _ = h.WriteString(key)
+	stripeIdx := uint64(64-1) & h.Sum64()
+	stripe := m.stripes[stripeIdx]
+	stripe.m.Lock()
+	defer stripe.m.Unlock()
+
+	stripe.store[key] = value
+	if len(stripe.store) <= m.sizePerGoroutine {
+		return
+	}
+	stripe.deletionProbeIdx++
+	if stripe.deletionProbeIdx >= stripe.deletionProbeBoundary {
+		stripe.deletionProbeIdx = 0
+	}
+	idx := 0
+	for k := range stripe.store {
+		if idx == stripe.deletionProbeIdx {
+			delete(stripe.store, k)
+			break
+		}
+		stripeIdx++
+	}
+}
+
+type mutexMapCache struct {
+	m                     sync.RWMutex
+	sizePerGoroutine      int
+	deletionProbeIdx      int
+	deletionProbeBoundary int
+	store                 map[string]interface{}
+}
+
+func newMutexCache(sizePerGoroutine uint) *mutexMapCache {
+	return &mutexMapCache{
+		m:                     sync.RWMutex{},
+		sizePerGoroutine:      int(sizePerGoroutine),
+		deletionProbeIdx:      0,
+		deletionProbeBoundary: 8,
+		store:                 make(map[string]interface{}),
+	}
+}
+
+func (m *mutexMapCache) Load(key string) (interface{}, bool) {
+	m.m.RLock()
+	defer m.m.RUnlock()
+	val, ok := m.store[key]
+	return val, ok
+}
+
+func (m *mutexMapCache) Store(key string, value interface{}) {
+	m.m.Lock()
+	defer m.m.Unlock()
+	m.store[key] = value
+	if len(m.store) <= m.sizePerGoroutine {
+		return
+	}
+	m.deletionProbeIdx++
+	if m.deletionProbeIdx >= m.deletionProbeBoundary {
+		m.deletionProbeIdx = 0
+	}
+	idx := 0
+	for k := range m.store {
+		if idx == m.deletionProbeIdx {
+			delete(m.store, k)
+			break
+		}
+		idx++
+	}
+}


### PR DESCRIPTION
Added benchmarks and comparison with two base line cache implementations `RWMutex` based cache and Striped `RWMutex` based cache.

Results on 3.8 GHz 8-Core Intel Core i7

```
name                           time/op
PCacheLoadStore/w-1-16          160ns ± 2%
PCacheLoadStore/w-2-16          165ns ± 1%
PCacheLoadStore/w-4-16          172ns ± 1%
PCacheLoadStore/w-8-16          195ns ± 2%
PCacheLoadStore/w-12-16         257ns ± 1%
PCacheLoadStore/w-16-16         359ns ± 2%
PCacheLoadStore/w-22-16         534ns ± 4%
PCacheLoadStore/w-28-16         673ns ± 3%
PCacheLoadStore/w-32-16         793ns ± 3%
MutexCacheLoadStore/w-1-16      143ns ± 1%
MutexCacheLoadStore/w-2-16      320ns ± 0%
MutexCacheLoadStore/w-4-16      715ns ± 0%
MutexCacheLoadStore/w-8-16     1.49µs ± 0%
MutexCacheLoadStore/w-12-16    2.19µs ± 0%
MutexCacheLoadStore/w-16-16    2.96µs ± 0%
MutexCacheLoadStore/w-22-16    4.13µs ± 0%
MutexCacheLoadStore/w-28-16    5.19µs ± 0%
MutexCacheLoadStore/w-32-16    5.83µs ± 2%
StripedCacheLoadStore/w-1-16   1.06µs ± 0%
StripedCacheLoadStore/w-2-16   1.27µs ± 0%
StripedCacheLoadStore/w-4-16   1.59µs ± 0%
StripedCacheLoadStore/w-8-16   2.14µs ± 1%
StripedCacheLoadStore/w-12-16  2.92µs ± 0%
StripedCacheLoadStore/w-16-16  3.61µs ± 2%
StripedCacheLoadStore/w-22-16  4.07µs ± 1%
StripedCacheLoadStore/w-28-16  4.56µs ± 1%
StripedCacheLoadStore/w-32-16  5.03µs ± 3%
```

<img width="1914" alt="Screenshot 2020-09-14 at 23 25 26" src="https://user-images.githubusercontent.com/3532750/93144547-26aaf000-f6e2-11ea-99ec-cd8f43c20cec.png">
