### PR TITLE
Benchmark comparison with Ristretto v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/storozhukBM/pcache
 
 go 1.15
+
+require github.com/dgraph-io/ristretto v0.0.3


### PR DESCRIPTION
Results on 3.8 GHz 8-Core Intel Core i7

```
name                           time/op
RistrettoLoadStore/w-1-16       544ns ± 0%
RistrettoLoadStore/w-2-16       892ns ± 0%
RistrettoLoadStore/w-4-16      1.63µs ± 0%
RistrettoLoadStore/w-8-16      3.42µs ± 0%
RistrettoLoadStore/w-12-16     4.78µs ± 0%
RistrettoLoadStore/w-16-16     6.72µs ± 1%
RistrettoLoadStore/w-22-16     8.83µs ± 1%
RistrettoLoadStore/w-28-16     11.5µs ± 1%
RistrettoLoadStore/w-32-16     13.7µs ± 0%
PCacheLoadStore/w-1-16          162ns ± 2%
PCacheLoadStore/w-2-16          165ns ± 2%
PCacheLoadStore/w-4-16          172ns ± 2%
PCacheLoadStore/w-8-16          193ns ± 2%
PCacheLoadStore/w-12-16         274ns ± 1%
PCacheLoadStore/w-16-16         417ns ± 8%
PCacheLoadStore/w-22-16         593ns ± 8%
PCacheLoadStore/w-28-16         713ns ± 7%
PCacheLoadStore/w-32-16         875ns ± 7%
MutexCacheLoadStore/w-1-16      140ns ± 0%
MutexCacheLoadStore/w-2-16      325ns ± 1%
MutexCacheLoadStore/w-4-16      727ns ± 0%
MutexCacheLoadStore/w-8-16     1.48µs ± 1%
MutexCacheLoadStore/w-12-16    2.23µs ± 0%
MutexCacheLoadStore/w-16-16    2.93µs ± 0%
MutexCacheLoadStore/w-22-16    4.15µs ± 0%
MutexCacheLoadStore/w-28-16    5.11µs ± 1%
MutexCacheLoadStore/w-32-16    6.01µs ± 0%
StripedCacheLoadStore/w-1-16   1.04µs ± 0%
StripedCacheLoadStore/w-2-16   1.24µs ± 0%
StripedCacheLoadStore/w-4-16   1.59µs ± 0%
StripedCacheLoadStore/w-8-16   2.12µs ± 0%
StripedCacheLoadStore/w-12-16  2.94µs ± 1%
StripedCacheLoadStore/w-16-16  3.63µs ± 2%
StripedCacheLoadStore/w-22-16  4.07µs ± 1%
StripedCacheLoadStore/w-28-16  4.58µs ± 1%
StripedCacheLoadStore/w-32-16  4.97µs ± 1%
```
## Linear scale
<img width="1791" alt="Screenshot 2020-09-15 at 00 10 58" src="https://user-images.githubusercontent.com/3532750/93146993-2d3c6600-f6e8-11ea-8e7d-276e9ca33cc3.png">

## Logarithmic scale

<img width="1794" alt="Screenshot 2020-09-15 at 00 11 25" src="https://user-images.githubusercontent.com/3532750/93147050-53620600-f6e8-11ea-8251-8b01e7b75402.png">

